### PR TITLE
Adding ContentMediaType element

### DIFF
--- a/src/app/WebValidation/Main.cs
+++ b/src/app/WebValidation/Main.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace CSE.WebValidate
 {
@@ -405,7 +406,16 @@ namespace CSE.WebValidate
                 // add the body to the http request
                 if (!string.IsNullOrEmpty(request.Body))
                 {
-                    req.Content = new StringContent(request.Body);
+                    if (!string.IsNullOrEmpty(request.ContentMediaType))
+                    {
+                        req.Content = new StringContent(request.Body,Encoding.UTF8,request.ContentMediaType);
+                    }
+                    else
+                    {
+                        req.Content = new StringContent(request.Body);
+                    }
+
+                        
                 }
 
                 // process the response

--- a/src/app/WebValidation/Model/Request.cs
+++ b/src/app/WebValidation/Model/Request.cs
@@ -9,6 +9,8 @@ namespace CSE.WebValidate.Model
         public bool FailOnValidationError { get; set; } = false;
         public string Body { get; set; }
         public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>();
+        public string ContentMediaType { get; set; }
+
         public PerfTarget PerfTarget { get; set; }
         public Validation Validation { get; set; }
     }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [X ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR
Adding ContentMediaType element to Request.cs class to defined the POST payload type. Right now code accept payload as "text/html; charset=UTF-8" and there is no option to defined it as application/json. 
### Validation
- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

### Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)

