### PR TITLE
Updating Summary format output to emit Junit format XML for rendering in Azure Devops

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ We use the `--log-format json` command line option to integrate Docker container
     - default `false`
 - --summary
   - SUMMARY
-    - Display test summary (None, Tsv, Json, JsonCamel, XML)
+    - Display test summary (None, Tsv, Json, JsonCamel, XML, Junit)
     - default `None`
 - --tag string
   - TAG

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ We use the `--log-format json` command line option to integrate Docker container
     - default `false`
 - --summary
   - SUMMARY
-    - Display test summary (None, Tsv, Json, JsonCamel, XML, Junit)
+    - Display test summary (None, Tsv, Json, JsonCamel, Xml)
+    - Xml output is in [JUnit](https://llg.cubic.org/docs/junit/) format
+    - Xml format summary - Creates a temporary json file (temp.json) to keep the details of test runs which is deleted after each run of webv. Works for RunOnce only.
     - default `None`
 - --tag string
   - TAG

--- a/src/app/WebValidation/Model/PerfLog.cs
+++ b/src/app/WebValidation/Model/PerfLog.cs
@@ -21,6 +21,10 @@ namespace CSE.WebValidate.Model
             Errors = validationErrors;
         }
 
+        public PerfLog()
+        {
+        }
+
         /// <summary>
         /// Gets the Type (defaults to request)
         /// </summary>
@@ -177,6 +181,15 @@ namespace CSE.WebValidate.Model
                 log += "\n  " + string.Join("\n  ", Errors);
             }
 
+            return log;
+        }
+
+        public string ToXml()
+        {
+            string log = "<testcase classname=\"" + ((Tag == null) ? string.Empty : (Tag + ": ")) + Verb + ": " + Path +
+                        "\" name=\"" + ((Tag == null) ? string.Empty : (Tag + ": ")) + Verb + ": " + Path +
+                        "\" time=\"" + TimeSpan.FromMilliseconds(Duration).TotalSeconds + "\">" +
+                        ((ErrorCount >= 1) ? ("<failure message=\"" + string.Join("\n", Errors) + "\"></failure>") : "<system-out></system-out>") + "</testcase>";
             return log;
         }
     }

--- a/src/app/WebValidation/Model/config.cs
+++ b/src/app/WebValidation/Model/config.cs
@@ -36,12 +36,7 @@ namespace CSE.WebValidate
         /// <summary>
         /// XML
         /// </summary>
-        Xml,
-
-        /// <summary>
-        /// Junit styled xml
-        /// </summary>
-        Junit
+        Xml
     }
 
     /// <summary>

--- a/src/app/WebValidation/Model/config.cs
+++ b/src/app/WebValidation/Model/config.cs
@@ -37,6 +37,11 @@ namespace CSE.WebValidate
         /// XML
         /// </summary>
         Xml,
+
+        /// <summary>
+        /// Junit styled xml
+        /// </summary>
+        Junit
     }
 
     /// <summary>

--- a/src/app/core/CommandLine.cs
+++ b/src/app/core/CommandLine.cs
@@ -70,7 +70,7 @@ namespace CSE.WebValidate
             OptionResult serverRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "server") as OptionResult;
             OptionResult filesRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "files") as OptionResult;
             OptionResult durationRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "duration") as OptionResult;
-            OptionResult formatRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "c") as OptionResult;
+            OptionResult formatRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "log-format") as OptionResult;
             OptionResult portRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "port") as OptionResult;
 
             bool runLoop = result.Children.FirstOrDefault(c => c.Symbol.Name == "run-loop") is OptionResult runLoopRes && runLoopRes.GetValueOrDefault<bool>();

--- a/src/app/core/CommandLine.cs
+++ b/src/app/core/CommandLine.cs
@@ -70,7 +70,7 @@ namespace CSE.WebValidate
             OptionResult serverRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "server") as OptionResult;
             OptionResult filesRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "files") as OptionResult;
             OptionResult durationRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "duration") as OptionResult;
-            OptionResult formatRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "log-format") as OptionResult;
+            OptionResult formatRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "c") as OptionResult;
             OptionResult portRes = result.Children.FirstOrDefault(c => c.Symbol.Name == "port") as OptionResult;
 
             bool runLoop = result.Children.FirstOrDefault(c => c.Symbol.Name == "run-loop") is OptionResult runLoopRes && runLoopRes.GetValueOrDefault<bool>();


### PR DESCRIPTION
# Type of PR

- [ X] Documentation changes
- [ X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
At Present the webvalidate tool emits the individual test runs in diff formats, this update enables the webvalidate tool to emit the JUnit format xml which can be rendered by Azure Devops.

## Validation

- [X] Unit tests updated and ran successfully
- [X] Update documentation or issue referenced above
- [X] Tested with an Azure DevOps pipeline

## Issues Closed or Referenced

- Closes #20 https://github.com/microsoft/webvalidate/issues/20
