### PR TITLE
Non Stringified request and response will be accepted now

### DIFF
--- a/src/app/WebValidation/Main.cs
+++ b/src/app/WebValidation/Main.cs
@@ -368,15 +368,15 @@ namespace CSE.WebValidate
                 req.Headers.Add(CorrelationVector.HeaderName, cv.Value);
 
                 // add the body to the http request
-                if (!string.IsNullOrWhiteSpace(request.Body))
+                if (request.Body != null)
                 {
                     if (!string.IsNullOrWhiteSpace(request.ContentMediaType))
                     {
-                        req.Content = new StringContent(request.Body, Encoding.UTF8, request.ContentMediaType);
+                        req.Content = new StringContent(request.Body.ToString(), Encoding.UTF8, request.ContentMediaType);
                     }
                     else
                     {
-                        req.Content = new StringContent(request.Body);
+                        req.Content = new StringContent(request.Body.ToString());
                     }
                 }
 

--- a/src/app/WebValidation/Model/Request.cs
+++ b/src/app/WebValidation/Model/Request.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace CSE.WebValidate.Model
 {
@@ -39,7 +40,7 @@ namespace CSE.WebValidate.Model
         /// <summary>
         /// Gets or sets the request body
         /// </summary>
-        public string Body { get; set; }
+        public JObject Body { get; set; }
 
         /// <summary>
         /// Gets the request header dictionary

--- a/src/app/WebValidation/Model/Validation.cs
+++ b/src/app/WebValidation/Model/Validation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace CSE.WebValidate.Model
 {
@@ -61,7 +62,7 @@ namespace CSE.WebValidate.Model
         /// <summary>
         /// gets or sets the string that must exactly match the response
         /// </summary>
-        public string ExactMatch { get; set; }
+        public JObject ExactMatch { get; set; }
 
         /// <summary>
         /// gets or sets the json array properties

--- a/src/app/WebValidation/ReadValidateJson.cs
+++ b/src/app/WebValidation/ReadValidateJson.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json;
 using CSE.WebValidate.Model;
 using CSE.WebValidate.Validators;
+using Newtonsoft.Json.Linq;
 
 namespace CSE.WebValidate
 {
@@ -186,7 +187,9 @@ namespace CSE.WebValidate
                 List<Request> l2 = new ();
 
                 // parse the json
-                data = JsonSerializer.Deserialize<InputJson>(json, App.JsonOptions);
+                JObject jsonObject = JObject.Parse(json);
+                data = jsonObject.ToObject<InputJson>();
+                //data = JsonSerializer.Deserialize<InputJson>(json, App.JsonOptions);
 
                 // replace placedholders with environment variables
                 if (data != null && data.Requests.Count > 0)

--- a/src/app/WebValidation/Validators/ParameterValidator.cs
+++ b/src/app/WebValidation/Validators/ParameterValidator.cs
@@ -70,8 +70,8 @@ namespace CSE.WebValidate.Validators
                 res.ValidationErrors.Add("contentType: ContentType cannot be empty");
             }
 
-            // validate ExactMatch
-            if (v.ExactMatch != null && v.ExactMatch.Length == 0)
+            // validate ExactMatch of Json Object
+            if (v.ExactMatch == null)
             {
                 res.Failed = true;
                 res.ValidationErrors.Add("exactMatch: exactMatch cannot be empty string");

--- a/src/app/WebValidation/Validators/ResponseValidator.cs
+++ b/src/app/WebValidation/Validators/ResponseValidator.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using CSE.WebValidate.Model;
+using Newtonsoft.Json.Linq;
 
 namespace CSE.WebValidate.Validators
 {
@@ -338,7 +339,7 @@ namespace CSE.WebValidate.Validators
         /// <param name="exactMatch">value to match</param>
         /// <param name="body">response body</param>
         /// <returns>ValidationResult</returns>
-        public static ValidationResult ValidateExactMatch(string exactMatch, string body)
+        public static ValidationResult ValidateExactMatch(JObject exactMatch, string body)
         {
             ValidationResult result = new ();
 
@@ -355,9 +356,10 @@ namespace CSE.WebValidate.Validators
             }
 
             // compare values
-            if (body != exactMatch)
+            JObject responseBody = JObject.Parse(body);
+            if (responseBody.ToString() != exactMatch.ToString())
             {
-                result.ValidationErrors.Add($"ExactMatch: {body} : Expected: {exactMatch}");
+                result.ValidationErrors.Add($"ExactMatch: {responseBody.ToString()} : Expected: {exactMatch.ToString()}");
             }
 
             return result;

--- a/src/app/webvalidate.csproj
+++ b/src/app/webvalidate.csproj
@@ -28,12 +28,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference> 
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" /> 
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Type of PR

Code Change

## Purpose of PR

Webv currently accepts escaped stringified jsons in request body and exact match response. Making code changes so that webv accepts direct valid request body and exact match jsons without the need for them to be stringified and escaped.

This is needed as it is a time taking task to stringify and escape all request and response exact matches(specially if there are more than 300 test cases) before saving them in a test json file.

## Validation

TO DO

## Issues Closed or Referenced

This aims to close issue: #22
