### PR TITLE
Lakaushi/convert request body and exact match

### DIFF
--- a/src/app/WebValidation/ReadValidateJson.cs
+++ b/src/app/WebValidation/ReadValidateJson.cs
@@ -191,13 +191,13 @@ namespace CSE.WebValidate
                 int length = ((JArray)jsonObject["requests"]).Count;
                 for (int testCaseNumber = 0; testCaseNumber < length; testCaseNumber++)
                 {
-                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString() == "application/json-patch+json" && jsonObject["requests"][testCaseNumber]["body"] != null && (jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": {") || jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": [")))
+                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["body"] != null && (jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": {") || jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": [")))
                 {
                 var requestBody = jsonObject["requests"][testCaseNumber]["body"].ToString(Newtonsoft.Json.Formatting.None);
                 jsonObject["requests"][testCaseNumber]["body"] = requestBody;
                 }
 
-                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString() == "application/json-patch+json" && jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] != null && (jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": {") || jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": [")))
+                if (jsonObject["requests"][testCaseNumber]["validation"]["contentType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] != null && (jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": {") || jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": [")))
                 {
                 var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
                 jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] = match;

--- a/src/app/WebValidation/ReadValidateJson.cs
+++ b/src/app/WebValidation/ReadValidateJson.cs
@@ -191,11 +191,15 @@ namespace CSE.WebValidate
                 int length = ((JArray)jsonObject["requests"]).Count;
                 for (int testCaseNumber = 0; testCaseNumber < length; testCaseNumber++)
                 {
-                if (jsonObject["requests"]["contentMediaType"].ToString() == "application/json-patch+json")
+                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString() == "application/json-patch+json" && jsonObject["requests"][testCaseNumber]["body"] != null && (jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": {") || jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": [")))
                 {
                 var requestBody = jsonObject["requests"][testCaseNumber]["body"].ToString(Newtonsoft.Json.Formatting.None);
-                var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
                 jsonObject["requests"][testCaseNumber]["body"] = requestBody;
+                }
+
+                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString() == "application/json-patch+json" && jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] != null && (jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": {") || jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": [")))
+                {
+                var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
                 jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] = match;
                 }
                 }

--- a/src/app/WebValidation/ReadValidateJson.cs
+++ b/src/app/WebValidation/ReadValidateJson.cs
@@ -190,19 +190,19 @@ namespace CSE.WebValidate
                 JObject jsonObject = JObject.Parse(json);
                 int length = ((JArray)jsonObject["requests"]).Count;
                 for (int testCaseNumber = 0; testCaseNumber < length; testCaseNumber++)
-                {
-                if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["body"] != null && (jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": {") || jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": [")))
-                {
-                var requestBody = jsonObject["requests"][testCaseNumber]["body"].ToString(Newtonsoft.Json.Formatting.None);
-                jsonObject["requests"][testCaseNumber]["body"] = requestBody;
-                }
+                    {
+                        if (jsonObject["requests"][testCaseNumber]["contentMediaType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["body"] != null && (jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": {") || jsonObject["requests"][testCaseNumber].ToString().Contains("\"body\": [")))
+                            {
+                                var requestBody = jsonObject["requests"][testCaseNumber]["body"].ToString(Newtonsoft.Json.Formatting.None);
+                                jsonObject["requests"][testCaseNumber]["body"] = requestBody;
+                            }
 
-                if (jsonObject["requests"][testCaseNumber]["validation"]["contentType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] != null && (jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": {") || jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": [")))
-                {
-                var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
-                jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] = match;
-                }
-                }
+                        if ((jsonObject["requests"][testCaseNumber]["validation"] != null) && jsonObject["requests"][testCaseNumber]["validation"]["contentType"].ToString().Contains("application/json") && jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] != null && (jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": {") || jsonObject["requests"][testCaseNumber]["validation"].ToString().Contains("\"exactMatch\": [")))
+                            {
+                                var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
+                                jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] = match;
+                            }
+                    }
 
                 var finalBody = jsonObject.ToString();
                 data = JsonSerializer.Deserialize<InputJson>(finalBody, App.JsonOptions);

--- a/src/app/WebValidation/ReadValidateJson.cs
+++ b/src/app/WebValidation/ReadValidateJson.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json;
 using CSE.WebValidate.Model;
 using CSE.WebValidate.Validators;
+using Newtonsoft.Json.Linq;
 
 namespace CSE.WebValidate
 {
@@ -186,7 +187,21 @@ namespace CSE.WebValidate
                 List<Request> l2 = new ();
 
                 // parse the json
-                data = JsonSerializer.Deserialize<InputJson>(json, App.JsonOptions);
+                JObject jsonObject = JObject.Parse(json);
+                int length = ((JArray)jsonObject["requests"]).Count;
+                for (int testCaseNumber = 0; testCaseNumber < length; testCaseNumber++)
+                {
+                if (jsonObject["requests"]["contentMediaType"].ToString() == "application/json-patch+json")
+                {
+                var requestBody = jsonObject["requests"][testCaseNumber]["body"].ToString(Newtonsoft.Json.Formatting.None);
+                var match = jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"].ToString(Newtonsoft.Json.Formatting.None);
+                jsonObject["requests"][testCaseNumber]["body"] = requestBody;
+                jsonObject["requests"][testCaseNumber]["validation"]["exactMatch"] = match;
+                }
+                }
+
+                var finalBody = jsonObject.ToString();
+                data = JsonSerializer.Deserialize<InputJson>(finalBody, App.JsonOptions);
 
                 // replace placedholders with environment variables
                 if (data != null && data.Requests.Count > 0)

--- a/src/app/webvalidate.csproj
+++ b/src/app/webvalidate.csproj
@@ -28,6 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Type of PR

Code Change

## Purpose of PR

As of now webv doesn't accept request body and exact match as actual json objects. 
Something like this is supported:

{
        "path": "/api/v0.1/Myapi/",
        "verb": "PUT",
        "tag": "TestCaseName",
        "failOnValidationError": true,
        "contentMediaType": "application/json-patch+json",
        "body": "{\"Code\":200,\"Message\":\"This is a String\",\"Details\":null}",
        "validation": {
          "statusCode": 404,
          "contentType": "application/json",
          "exactMatch": "{\"Code\":200,\"Message\":\"This is a String\",\"Details\":null}"
        }
      }

But something like below is not supported as request body and exact matches are not escaped json strings. 


{
        "path": "/api/v0.1/Myapi/",
        "verb": "PUT",
        "tag": "TestCaseName",
        "failOnValidationError": true,
        "contentMediaType": "application/json-patch+json",
        "body": {"Code":200,"Message":"This is a String","Details":null},
        "validation": {
          "statusCode": 404,
          "contentType": "application/json",
          "exactMatch": {"Code":200,"Message":"This is a String","Details":null}
        }
      }

Practically it takes a lot of time for an engineer to stringify and escape all request body and exact match before putting them into webv test format when there are high number of test cases. Hence this PR so that above format in which requests body and exactMatch are accepted as Json Objects.

As part of this PR both the stringified/escaped and non stringified jsons will be supported.

## Validation


## Issues Closed or Referenced

This issue closes #22
